### PR TITLE
Windows CI: Fix vcpkg caching by removing quotes surrounding the paths

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -134,10 +134,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            "${{ github.workspace }}\vcpkgAssets"
-            "${{ github.workspace }}\vcpkgBCache"
-            "${{ github.workspace }}\vcpkgBin"
-            "${{ github.workspace }}\vcpkgBuild"
+            ${{ github.workspace }}\vcpkgAssets
+            ${{ github.workspace }}\vcpkgBCache
+            ${{ github.workspace }}\vcpkgBin
+            ${{ github.workspace }}\vcpkgBuild
           key: vcpkgCache-${{ github.repository_owner }}-${{ matrix.os }}-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json') }}
 
       - name: Create directories on cache miss
@@ -169,10 +169,10 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            "${{ github.workspace }}\vcpkgAssets"
-            "${{ github.workspace }}\vcpkgBCache"
-            "${{ github.workspace }}\vcpkgBin"
-            "${{ github.workspace }}\vcpkgBuild"
+            ${{ github.workspace }}\vcpkgAssets
+            ${{ github.workspace }}\vcpkgBCache
+            ${{ github.workspace }}\vcpkgBin
+            ${{ github.workspace }}\vcpkgBuild
           key: ${{ steps.cache-vcpkg-restore.outputs.cache-primary-key }}
         if: steps.cache-vcpkg-restore.outputs.cache-hit != 'true'
 


### PR DESCRIPTION
Fixes #102 .